### PR TITLE
feat: load only thumbnails for .tif images (TT-1314)

### DIFF
--- a/src/lib/FileTree.svelte
+++ b/src/lib/FileTree.svelte
@@ -35,22 +35,27 @@
                             <button class="expand-btn" on:click={() => file.opened = !file.opened}>
                                 <ChevronDown size="16" color="gray"/>
                             </button>
+                            <button
+                                class="expand-btn"
+                                on:click|preventDefault={() => changeViewDirectory(file)}
+                                on:keydown|preventDefault={() => changeViewDirectory(file)}
+                            >
+                                <FolderOpen size="16"/>
+                                <span>{formatFileNames(file.name)}</span>
+                            </button>
                         {:else}
                             <button class="expand-btn" on:click={() => file.opened = !file.opened}>
                                 <ChevronRight size="16" color="gray"/>
                             </button>
-                        {/if}
-                        <button class="expand-btn"
-                            on:click|preventDefault={() => changeViewDirectory(file)}
-                            on:keydown|preventDefault={() => changeViewDirectory(file)}
-                        >
-                            {#if file.opened}
-                                <FolderOpen size="16"/>
-                            {:else}
+                            <button
+                                class="expand-btn"
+                                on:click|preventDefault={() => changeViewDirectory(file)}
+                                on:keydown|preventDefault={() => changeViewDirectory(file)}
+                            >
                                 <Folder size="16"/>
-                            {/if}
-                            <span>{formatFileNames(file.name)}</span>
-                        </button>
+                                <span>{formatFileNames(file.name)}</span>
+                            </button>
+                        {/if}
                     {/if}
                     {#if file.opened && !file.name.startsWith('.')}
                         <ul>

--- a/src/lib/FileTree.svelte
+++ b/src/lib/FileTree.svelte
@@ -2,6 +2,7 @@
     import {ChevronDown, ChevronRight, FileImage, Folder, FolderOpen} from 'lucide-svelte';
     import {beforeUpdate, createEventDispatcher} from "svelte";
     import {FileTree} from "./model/file-tree";
+    import {formatFileNames} from "./util/file-utils";
 
     export let fileTree: FileTree[] = []
     const dispatch = createEventDispatcher()
@@ -22,12 +23,6 @@
         dispatch('directoryChange', file)
     }
 
-    function formatFileNames(fileName: string): string {
-        if (fileName.endsWith('.tif')) return fileName.replace('.tif', '')
-        if (fileName.endsWith('.webp')) return fileName.replace('.webp', '')
-        return fileName
-    }
-
 </script>
 
 <div>
@@ -35,27 +30,29 @@
         {#each fileTree as file}
             {#if file.children}
                 <li>
-                    {#if file.opened}
-                        <button class="expand-btn" on:click={() => file.opened = !file.opened}>
-                            <ChevronDown size="16" color="gray"/>
-                        </button>
-                    {:else}
-                        <button class="expand-btn" on:click={() => file.opened = !file.opened}>
-                            <ChevronRight size="16" color="gray"/>
+                    {#if !file.name.startsWith('.')}
+                        {#if file.opened}
+                            <button class="expand-btn" on:click={() => file.opened = !file.opened}>
+                                <ChevronDown size="16" color="gray"/>
+                            </button>
+                        {:else}
+                            <button class="expand-btn" on:click={() => file.opened = !file.opened}>
+                                <ChevronRight size="16" color="gray"/>
+                            </button>
+                        {/if}
+                        <button class="expand-btn"
+                            on:click|preventDefault={() => changeViewDirectory(file)}
+                            on:keydown|preventDefault={() => changeViewDirectory(file)}
+                        >
+                            {#if file.opened}
+                                <FolderOpen size="16"/>
+                            {:else}
+                                <Folder size="16"/>
+                            {/if}
+                            <span>{formatFileNames(file.name)}</span>
                         </button>
                     {/if}
-                    <button class="expand-btn"
-                        on:click|preventDefault={() => changeViewDirectory(file)}
-                        on:keydown|preventDefault={() => changeViewDirectory(file)}
-                    >
-                        {#if file.opened}
-                            <FolderOpen size="16"/>
-                        {:else}
-                            <Folder size="16"/>
-                        {/if}
-                        <span>{formatFileNames(file.name)}</span>
-                    </button>
-                    {#if file.opened}
+                    {#if file.opened && !file.name.startsWith('.')}
                         <ul>
                             <svelte:self fileTree={file.children} on:directoryChange />
                         </ul>

--- a/src/lib/Files.svelte
+++ b/src/lib/Files.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
     import {readDir} from '@tauri-apps/api/fs'
-    import {onDestroy, onMount} from 'svelte';
+    import {beforeUpdate, onDestroy, onMount} from 'svelte';
     import {convertFileSrc} from "@tauri-apps/api/tauri";
     import RegistrationSchema from "./RegistrationSchema.svelte";
     import {invoke} from "@tauri-apps/api";
     import FileTree from "./FileTree.svelte";
     import {watch} from "tauri-plugin-fs-watch-api";
-    import {ChevronsDownUp, ChevronsUpDown} from "lucide-svelte";
+    import {ChevronsDownUp, ChevronsUpDown, File, Folder} from "lucide-svelte";
     import {FileTree as FileTreeType} from "./model/file-tree";
     import {type UnlistenFn} from "@tauri-apps/api/event";
     import {type ViewFile} from "./model/view-file";
+    import {formatFileNames} from "./util/file-utils";
 
     export let scannerPath: string
 
@@ -18,6 +19,7 @@
     let fileTree: FileTreeType[] = []
     let viewFiles: ViewFile[] = []
     let stopWatching: UnlistenFn | void | null = null
+    const supportedFileTypes = ["jpeg", "jpg", "png", "gif", "webp"]
 
     $: readDir(scannerPath, {recursive: true})
         .then(newFiles => {
@@ -34,9 +36,21 @@
         await watchFiles()
     })
 
+    beforeUpdate(() => {
+        viewFiles = sortViewFiles()
+    })
+
     onDestroy(() => {
         unwatchFiles()
     })
+
+    function sortViewFiles(): ViewFile[] {
+        return viewFiles.sort((a, b) => {
+            if (a.fileTree.name < b.fileTree.name) return -1
+            if (a.fileTree.name > b.fileTree.name) return 1
+            return 0
+        });
+    }
 
     async function watchFiles() {
         if (stopWatching) {
@@ -105,19 +119,28 @@
         })
     }
 
-    function changeViewDirectory(fileEntry: FileTreeType): void {
-        currentPath = fileEntry.path
-        viewFiles = []
-        if (fileEntry.children) {
-            fileEntry.children.forEach((file: FileTreeType) => {
+    function addViewFile(fileEntry: FileTreeType) {
+        fileEntry?.children?.forEach((file: FileTreeType) => {
+            if (!file.name.startsWith(".thumbnails") && !file.name.endsWith(".tif")) {
                 viewFiles.push({
                     fileTree: file,
                     imageSource: convertFileSrc(file.path)
                 })
-                if (file.path.endsWith(".tif")) {
-                    createThumbnail(file.path)
-                }
-            })
+            }
+            if (file.name.endsWith(".tif")) {
+                createThumbnail(file.path)
+            }
+            if (file.children && file.path.endsWith(".thumbnails")) {
+                addViewFile(file)
+            }
+        })
+    }
+
+    function changeViewDirectory(fileEntry: FileTreeType): void {
+        currentPath = fileEntry.path
+        viewFiles = []
+        if (fileEntry.children) {
+            addViewFile(fileEntry);
         } else {
             viewFiles.push({
                 fileTree: fileEntry,
@@ -136,7 +159,10 @@
             }
         })
         fileTree = [...fileTree]
+    }
 
+    function getFileExtension(path: string): string {
+        return path.split('%2F').pop()?.split('.')?.pop()?.toLowerCase() || ""
     }
 </script>
 
@@ -156,10 +182,18 @@
         <div class="images">
             {#each viewFiles as viewFile}
                 {#if viewFile.fileTree.children}
-                    <p>directory</p>
-                {:else}
+                    <button class="directory" on:click={() => changeViewDirectory(viewFile.fileTree)}>
+                        <Folder size="96"/>
+                        <i>{viewFile.imageSource.split('%2F').pop()}</i>
+                    </button>
+                {:else if supportedFileTypes.includes(getFileExtension(viewFile.imageSource))}
                     <div>
                         <img src={viewFile.imageSource} alt={viewFile.fileTree.name}/>
+                        <i>{formatFileNames(viewFile.imageSource.split('%2F').pop())}</i>
+                    </div>
+                {:else}
+                    <div class="file">
+                        <File size="96" color="gray"/>
                         <i>{viewFile.imageSource.split('%2F').pop()}</i>
                     </div>
                 {/if}
@@ -208,6 +242,35 @@
       cursor: pointer;
       border: solid 3px red;
     }
+  }
+
+  .directory {
+    width: 150px;
+    min-height: 150px;
+    max-height: fit-content;
+    margin: auto .5em;
+    object-fit: contain;
+    border: solid 3px transparent;
+    border-radius: 3px;
+    text-align: center;
+    background: none;
+    padding: 0;
+    outline: none;
+    box-shadow: none;
+
+    &:hover {
+      cursor: pointer;
+      border: solid 3px deepskyblue;
+    }
+  }
+
+  .file {
+    width: 150px;
+    min-height: 150px;
+    max-height: fit-content;
+    margin: auto .5em;
+    object-fit: contain;
+    text-align: center;
   }
 
   i {

--- a/src/lib/Files.svelte
+++ b/src/lib/Files.svelte
@@ -128,11 +128,11 @@
                     imageSource: convertFileSrc(file.path)
                 })
             }
-            if (file.name.endsWith(".tif")) {
+            else if (file.name.endsWith(".tif")) {
                 createThumbnail(file.path)
             }
             // If the current file is the .thumbnail directory, add all files in it
-            if (file.children && file.path.endsWith(".thumbnails")) {
+            else if (file.children && file.path.endsWith(".thumbnails")) {
                 addViewFile(file)
             }
         })

--- a/src/lib/Files.svelte
+++ b/src/lib/Files.svelte
@@ -121,6 +121,7 @@
 
     function addViewFile(fileEntry: FileTreeType) {
         fileEntry?.children?.forEach((file: FileTreeType) => {
+            // Show all files except the .thumbnail directory and tif files
             if (!file.name.startsWith(".thumbnails") && !file.name.endsWith(".tif")) {
                 viewFiles.push({
                     fileTree: file,
@@ -130,6 +131,7 @@
             if (file.name.endsWith(".tif")) {
                 createThumbnail(file.path)
             }
+            // If the current file is the .thumbnail directory, add all files in it
             if (file.children && file.path.endsWith(".thumbnails")) {
                 addViewFile(file)
             }
@@ -162,7 +164,7 @@
     }
 
     function getFileExtension(path: string): string {
-        return path.split('%2F').pop()?.split('.')?.pop()?.toLowerCase() || ""
+        return path?.split('.')?.pop() || ""
     }
 </script>
 

--- a/src/lib/util/file-utils.ts
+++ b/src/lib/util/file-utils.ts
@@ -1,0 +1,5 @@
+export const formatFileNames = (fileName?: string): string => {
+    if (!fileName) return ''
+    if (fileName.endsWith('.webp')) return fileName.replace('.webp', '.tif')
+    return fileName
+}


### PR DESCRIPTION
TIFF files are no longer attempted loaded in the image tag, significantly improving performance when opening directories with many large .tif files. The generated webp thumbnails are loaded instead. The `.thumbnails` subdirectory is hidden from the user interface. Subdirectories are also now clickable from the grid view.